### PR TITLE
Migrer openapi-generator til Jackson 3 og Spring Boot 4

### DIFF
--- a/eux-relaterte-rinasaker-openapi/pom.xml
+++ b/eux-relaterte-rinasaker-openapi/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
-                <version>7.20.0</version>
+                <version>7.21.0</version>
                 <executions>
                     <execution>
                         <id>openapi-spring</id>
@@ -60,9 +60,8 @@
                             <configOptions>
                                 <sourceFolder>src/gen/java/main</sourceFolder>
                                 <interfaceOnly>true</interfaceOnly>
-                                <serializableModel>true</serializableModel>
-                                <useSpringBoot3>true</useSpringBoot3>
-                                <addCompileSourceRoot>true</addCompileSourceRoot>
+                                <useSpringBoot4>true</useSpringBoot4>
+                                <useJackson3>true</useJackson3>
                                 <useTags>true</useTags>
                                 <enumPropertyNaming>UPPERCASE</enumPropertyNaming>
                             </configOptions>

--- a/eux-relaterte-rinasaker-webapp/pom.xml
+++ b/eux-relaterte-rinasaker-webapp/pom.xml
@@ -34,10 +34,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-jackson2</artifactId>
-        </dependency>
 
         <!-- Kotlin -->
         <dependency>
@@ -65,7 +61,7 @@
             <artifactId>postgresql</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
+            <groupId>tools.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
         <dependency>

--- a/eux-relaterte-rinasaker-webapp/src/main/kotlin/no/nav/eux/relaterte/rinasaker/ApplicationConfig.kt
+++ b/eux-relaterte-rinasaker-webapp/src/main/kotlin/no/nav/eux/relaterte/rinasaker/ApplicationConfig.kt
@@ -1,12 +1,12 @@
 package no.nav.eux.relaterte.rinasaker
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.SerializationFeature
 import com.zaxxer.hikari.HikariDataSource
 import no.nav.eux.logging.RequestIdMdcFilter
-import org.springframework.boot.jackson2.autoconfigure.Jackson2ObjectMapperBuilderCustomizer
+import org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import tools.jackson.databind.DeserializationFeature
+import tools.jackson.databind.cfg.DateTimeFeature
 
 @Configuration
 class ApplicationConfig(
@@ -19,12 +19,10 @@ class ApplicationConfig(
     @Bean
     fun requestIdMdcFilter() = RequestIdMdcFilter()
 
-    @Suppress("removal")
     @Bean
-    fun jackson2ObjectMapperBuilderCustomizer() = Jackson2ObjectMapperBuilderCustomizer { builder ->
-        builder.featuresToDisable(
-            SerializationFeature.WRITE_DATES_AS_TIMESTAMPS,
-            DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
-        )
+    fun jsonMapperBuilderCustomizer() = JsonMapperBuilderCustomizer { builder ->
+        builder
+            .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
     }
 }

--- a/eux-relaterte-rinasaker-webapp/src/main/resources/application.yml
+++ b/eux-relaterte-rinasaker-webapp/src/main/resources/application.yml
@@ -17,10 +17,6 @@ spring:
       minimum-idle: 1
       initialization-fail-timeout: 60000
 
-  http:
-    converters:
-      preferred-json-mapper: jackson2
-
   jpa:
     open-in-view: false
 


### PR DESCRIPTION
Skrur på useSpringBoot4=true og useJackson3=true i openapi-generator
plugin og fjerner Jackson 2-hybriden:

- Fjerner spring-boot-jackson2 kompat-modul
- Bytter jackson-module-kotlin til tools.jackson.module-koordinaten
- Bytter Jackson2ObjectMapperBuilderCustomizer til
  JsonMapperBuilderCustomizer (Jackson 3 / Spring Boot 4)
- Flytter WRITE_DATES_AS_TIMESTAMPS fra SerializationFeature til
  DateTimeFeature (Jackson 3-flytting)
- Fjerner spring.http.converters.preferred-json-mapper: jackson2
- Rydder plugin configOptions: fjerner serializableModel,
  useSpringBoot3 og addCompileSourceRoot (default)

Lukker #22

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
