### PR TITLE
chore: bump parent-pom to 2.0.15, chainguard image, dependabot, Node 24 actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 6
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 4
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    reviewers:
+      - "navikt/eessibasis"
+    labels:
+      - "dependencies"
+      - "automerge"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/distroless/java25
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 COPY eux-relaterte-rinasaker-webapp/target/eux-relaterte-rinasaker.jar /app.jar
 ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
+ENV JDK_JAVA_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0"
 COPY eux-relaterte-rinasaker-webapp/target/eux-relaterte-rinasaker.jar /app.jar
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+CMD ["-jar", "/app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>no.nav.eux</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>2.0.10</version>
+        <version>2.0.15</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
## Endringer

- **parent-pom**: `2.0.10` → `2.0.15`
- **Dockerfile**: bytter fra `gcr.io/distroless/java25` til Chainguard `nav.no/jre:openjdk-25`, og bruker `CMD` i stedet for `ENTRYPOINT` (Chainguard-imaget har `java` som innebygd entrypoint)
- **dependabot**: legger til `.github/dependabot.yml` med daglig maven-oppdatering, cooldown, `chore`-prefix og `navikt/eessibasis` som reviewers
- **GitHub Actions**: bumper `actions/checkout@v4` → `@v6` i `build.yaml` for Node 24 (aligner med øvrige workflows)

## Ikke gjort
- Jackson-properties: ikke tilstede i noen pom.xml — ingenting å fjerne
- Lombok: ikke i bruk (rent Kotlin-prosjekt) — ingen bump nødvendig