### PR TITLE
chore(pom): bump opentelemetry to 1.63.0 to fix CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,18 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>1.63.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <scm>
         <connection>scm:git:https://github.com/navikt/eux-relaterte-rinasaker.git</connection>
         <developerConnection>scm:git:https://github.com/navikt/eux-relaterte-rinasaker.git</developerConnection>


### PR DESCRIPTION
## Problem
Vulnerability scan flags `io.opentelemetry:opentelemetry-api` and `io.opentelemetry:opentelemetry-extension-trace-propagators` at `1.55.0` (provided by parent-pom 2.0.15).
CVE fixed in 1.62.0.

## Løsning
Import `opentelemetry-bom:1.63.0` in `<dependencyManagement>` — this takes precedence over parent-pom's version pinning (property overrides don't work across BOM import boundaries in Maven).

Bumper alle `io.opentelemetry:*` transitive artifacts til 1.63.0:
- opentelemetry-api
- opentelemetry-extension-trace-propagators
- opentelemetry-sdk / sdk-trace / sdk-metrics / sdk-logs / sdk-common
- opentelemetry-context / opentelemetry-common