### PR TITLE
chore(pom): override opentelemetry to 1.63.0 to fix CVE in 1.55.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,18 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>1.63.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <scm>
         <connection>scm:git:https://github.com/navikt/eux-relaterte-rinasaker.git</connection>
         <developerConnection>scm:git:https://github.com/navikt/eux-relaterte-rinasaker.git</developerConnection>


### PR DESCRIPTION
Fixed in 1.62.0, using latest 1.63.0.