### PR TITLE
chore(deps): bump parent-pom to 2.0.20 (+ tomcat 11.0.24)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>no.nav.eux</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>2.0.16</version>
+        <version>2.0.20</version>
         <relativePath />
     </parent>
 
@@ -29,7 +29,28 @@
         <maven.compiler.source>25</maven.compiler.source>
         <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <tomcat.version>11.0.24</tomcat.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <scm>
         <connection>scm:git:https://github.com/navikt/eux-relaterte-rinasaker.git</connection>


### PR DESCRIPTION
## Hva
- Bumper `parent-pom` fra **2.0.16** til **2.0.20**.
- Pinner `tomcat-embed-*` eksplisitt til **11.0.24** via `dependencyManagement`.

## Hvorfor
Parent-pom 2.0.20 løfter Jackson 2 core/databind til 2.22.1 (verifisert med `dependency:tree`). Tomcat-embed styres ikke av parent-pom og henger på 11.0.22 fra Spring Boot-BOM (import-scope) — en `tomcat.version`-property alene slår ikke gjennom, derfor eksplisitt pin.

## Verifisert
- `dependency:tree`: tomcat-embed-core/el/websocket = 11.0.24, jackson2 core/databind = 2.22.1.
- `mvn clean install` (in-process Kotlin-compiler): BUILD SUCCESS.
- Full testsuite kjøres av CI (Postgres 17 service).

Del av opprydding etter runbook for eux-dependency-oppgaver.