### PR TITLE
ci: add least-privilege permissions to build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+  packages: read
+
 env:
   DATABASE_HOST: localhost
   DATABASE_PORT: 5432


### PR DESCRIPTION
## Hva
Legger til top-level `permissions`-blokk i `build.yaml`:
```yaml
permissions:
  contents: read
  packages: read
```

## Hvorfor
Least-privilege — workflowen bygger og tester kun (`mvn clean install`), ingen deploy/publish. `contents: read` for checkout, `packages: read` for å hente avhengigheter fra navikt GitHub Packages via `settings.xml`. Deploy skjer i egne `deploy-*.yaml`-workflows.

Del av opprydding etter runbook for eux-dependency-oppgaver.