### PR TITLE
chore: add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.idea
+*.iml
+**/target/*
+!eux-relaterte-rinasaker-webapp/target/eux-relaterte-rinasaker.jar
+**/src/test
+*.md
+docker-compose*.yml
+.env*
+.dockerignore
+Dockerfile


### PR DESCRIPTION
## Hva
Legger til `.dockerignore` (Dockerfilen er allerede på Nav JVM-standard, ingen endring der).

## Hvorfor
- Reduserer Docker build-context: ekskluderer `.git`, `.github`, IDE-filer, test-kildekode, markdown.
- `.env*` hindrer at hemmeligheter havner i build-context.
- Whitelister jaren Dockerfilen kopierer: `eux-relaterte-rinasaker-webapp/target/eux-relaterte-rinasaker.jar`.
- Bruker `**/target/*` og `**/src/test` tilpasset multi-modul-layouten.

Del av opprydding etter runbook for eux-dependency-oppgaver.