### PR TITLE
chore(deps): bump postgresql driver to 42.7.13

### DIFF
--- a/eux-relaterte-rinasaker-webapp/pom.xml
+++ b/eux-relaterte-rinasaker-webapp/pom.xml
@@ -59,6 +59,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+            <version>${postgresql.version}</version>
         </dependency>
         <dependency>
             <groupId>tools.jackson.module</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
+        <postgresql.version>42.7.13</postgresql.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Hva
Bumper `org.postgresql:postgresql` fra **42.7.11** til **42.7.13**.

## Hvorfor
Driveren arves fra parent-BOM uten eksplisitt versjon. En `postgresql.version`-property alene overstyrer ikke den BOM-administrerte versjonen (import-scope), derfor eksplisitt `<version>` på dependencyen i webapp.

## Verifisert
`dependency:tree`: `org.postgresql:postgresql:jar:42.7.13:compile`.

Del av opprydding etter runbook for eux-dependency-oppgaver.