### PR TITLE
chore(deps): bump netty to 4.2.16.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
         <postgresql.version>42.7.13</postgresql.version>
+        <netty.version>4.2.16.Final</netty.version>
     </properties>
 
     <dependencyManagement>
@@ -49,6 +50,13 @@
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-websocket</artifactId>
                 <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Hva
Bumper alle `io.netty:*`-artefakter fra **4.2.15.Final** til **4.2.16.Final** via `netty-bom`-import.

## Hvorfor
Netty trekkes inn transitivt (kun test-scope, via `spring-boot-starter-test`) og henger på 4.2.15.Final fra Spring Boot-BOM. `netty-bom`-import pinner hele familien konsistent.

## Verifisert
`dependency:tree`: alle `io.netty:*` = 4.2.16.Final.

Merk: netty er kun test-scope, ikke i runtime-jaren — lav risiko.

Del av opprydding etter runbook for eux-dependency-oppgaver.