### PR TITLE
chore(deps): pin jackson-bom to 2.22.1 to align all jackson2 modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,18 @@
         <tomcat.version>11.0.24</tomcat.version>
         <postgresql.version>42.7.13</postgresql.version>
         <netty.version>4.2.16.Final</netty.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson-2-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-core</artifactId>


### PR DESCRIPTION
## Hva
Importerer `com.fasterxml.jackson:jackson-bom:2.22.1` i `dependencyManagement` for å pinne alle Jackson 2-moduler konsistent.

## Hvorfor
Selv med parent-pom 2.0.20 henger enkelte Jackson 2-moduler (f.eks. `jackson-module-kotlin`, test-scope) på **2.21.4** fra Spring Boot-BOM (import-scope), mens `jackson-core`/`jackson-databind` er 2.22.1 — blandede versjoner innen samme familie. `jackson-bom`-import løser dette.

## Verifisert
- `dependency:tree`: alle `com.fasterxml.jackson:*` = 2.22.1 (`jackson-annotations` = 2.22, eget versjonsskjema). Ingen 2.21.x igjen.
- `mvn clean install` (in-process Kotlin-compiler): BUILD SUCCESS.

Del av opprydding etter runbook for eux-dependency-oppgaver.