### PR TITLE
chore(deps): bump kotlin to 2.4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <maven.compiler.source>25</maven.compiler.source>
         <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <kotlin.version>2.4.10</kotlin.version>
         <tomcat.version>11.0.24</tomcat.version>
         <postgresql.version>42.7.13</postgresql.version>
     </properties>


### PR DESCRIPTION
## Hva
Bumper Kotlin fra **2.3.21** til **2.4.10** ved å overstyre `kotlin.version`-property i root-pom.

## Kontekst
Kotlin arves i dag fra `parent-pom` (2.0.20 → 2.3.21). Ingen modul har lokal `kotlin.version`; alle bruker `${kotlin.version}`, så kotlin-maven-plugin og compiler-pluginene (jpa/spring/noarg/allopen) følger automatisk med.

## Verifisert
- `kotlin.version` resolver til 2.4.10.
- `mvn clean install -DskipTests` (in-process compiler): **BUILD SUCCESS** — main- og test-kildekode kompilerer i alle 6 moduler, ingen kompileringsfeil.
- Full testsuite (krever Postgres 17) kjøres av CI.

## ⚠️ Governance-merknad
Kotlin styres normalt sentralt via `eux-parent-pom`. Denne PR-en overstyrer den lokalt. Vurder om det heller bør løses ved å bumpe parent-pom, slik at alle eux-repoer følger samme Kotlin-versjon. Merges bare hvis lokal override er ønsket i påvente av parent-pom-oppdatering.