### PR TITLE
bump: eux-parent-pom 2.0.20 → 2.0.21

### DIFF
--- a/eux-relaterte-rinasaker-openapi/pom.xml
+++ b/eux-relaterte-rinasaker-openapi/pom.xml
@@ -27,7 +27,6 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <version>${kotlin.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.validation</groupId>
@@ -72,7 +71,6 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>${kotlin.version}</version>
                 <executions>
                     <execution>
                         <id>compile</id>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>no.nav.eux</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>2.0.20</version>
+        <version>2.0.21</version>
         <relativePath />
     </parent>
 
@@ -28,11 +28,8 @@
     <properties>
         <maven.compiler.source>25</maven.compiler.source>
         <maven.compiler.target>25</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tomcat.version>11.0.24</tomcat.version>
-        <postgresql.version>42.7.13</postgresql.version>
         <netty.version>4.2.16.Final</netty.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,6 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
         <tomcat.version>11.0.24</tomcat.version>
         <netty.version>4.2.16.Final</netty.version>
     </properties>


### PR DESCRIPTION
## Endringer

- Bump `eux-parent-pom` 2.0.20 → 2.0.21 (Kotlin 2.4.10, Spring Boot 4.1.0)

### Fjernede redundante properties/versjoner (arves fra parent)
| Hva | Grunn |
|-----|-------|
| `project.build.sourceEncoding` | identisk i parent |
| `postgresql.version` | identisk i parent |
| `jackson-2-bom.version` property | identisk i parent |
| `maven.compiler.source/target` | parent setter Java 21 (LTS) — lokal override til 25 fjernet |
| `kotlin-stdlib` version i openapi | håndteres av kotlin-bom (via parent) |
| `kotlin-maven-plugin` version i openapi | håndteres av parent pluginManagement |

### Beholdt (bevisst)
- `tomcat.version` / `netty.version` — ikke i parent
- `jackson-bom` BOM-import i dependencyManagement — parent importerer ikke denne